### PR TITLE
Remove redundant quotes

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule SparkPost.Mixfile do
        extras: ["README.md", "CONTRIBUTING.md", "CHANGELOG.md"]
      ],
      test_coverage: [tool: ExCoveralls],
-     preferred_cli_env: ["coveralls": :test, "coveralls.detail": :test, "coveralls.post": :test]
+     preferred_cli_env: [coveralls: :test, "coveralls.detail": :test, "coveralls.post": :test]
    ]
   end
 


### PR DESCRIPTION
To solve this warning while compiling:

```elixir
    warning: found quoted keyword "coveralls" but the quotes are not required. Note that keywords are always atoms, even when quoted. Similar to atoms, keywords made exclusively of ASCII letters, numbers, and underscores and not beginning with a number do not require quotes
    │
 18 │      preferred_cli_env: ["coveralls": :test, "coveralls.detail": :test, "coveralls.post": :test]
    │                           ~
    │
    └─ /Users/jonathanmoraes/Workspace/bofh-api/deps/sparkpost/mix.exs:18:27
```